### PR TITLE
fixes #1 - switches from peerDependency to dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,23 @@ jobs:
             cdk init sample-app --language typescript
             npm install cdk-dia@9.9.${GITHUB_RUN_NUMBER} --registry http://localhost:4873
 
-            # Use CLI and test expected PNG
+            ## Use CLI and test expected PNG
             cdk synth
             npx cdk-dia
+            test -s diagram.png && echo "diagram.png exists and has size > 0"
+            ls -la
+
+            # Use as a globally installed package
+            npm install -g typescript
+            npm install -g aws-cdk
+            npm install cdk-dia@9.9.${GITHUB_RUN_NUMBER} --registry http://localhost:4873 -g
+            sudo apt install graphviz
+            mkdir package-smoke-test-global
+            cd package-smoke-test-global
+            cdk init sample-app --language typescript
+
+            ## Use CLI and test expected PNG
+            cdk synth
+            cdk-dia
             test -s diagram.png && echo "diagram.png exists and has size > 0"
             ls -la

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-dia",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "🎡 Automated diagrams of CDK provisioned infrastructure",
   "scripts": {
     "prepare-dist": "./prepare-dist.sh",
@@ -26,9 +26,7 @@
     "ts-graphviz": "^0.13.2",
     "values.js": "^2.0.0",
     "word-wrap": "^1.2.3",
-    "yargs": "^16.2.0"
-  },
-  "peerDependencies": {
+    "yargs": "^16.2.0",
     "@aws-cdk/core": "^1.40.0"
   },
   "devDependencies": {


### PR DESCRIPTION
 in order to allow usage as a globally installed NPM packages.

downside: usage with rather old (>1.40.x) cdk versions might (low chance) face a compatibility issue.