### PR TITLE
Linked project

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -15,7 +15,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run test
-      - run: npm run prepare-dist
       - run: cd dist && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -15,6 +15,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run test
-      - run: cd dist && npm publish --access public
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -24,7 +24,7 @@ async function generateDiagram(args: cdkDiaCliArgs) {
         includedStacks = args.stacks.map(it => it.toString())
     }
 
-    const packageBasePath = path.dirname(require.resolve('cdk-dia/package.json'))
+    const packageBasePath = path.dirname(require.resolve('../../package.json'))
 
     cdkDia.generateDiagram(
         args["cdk-tree-path"],

--- a/examples/decoration-example/README.md
+++ b/examples/decoration-example/README.md
@@ -1,3 +1,7 @@
 # Decoration Example
 
 This example AWS-CDK project shows how one can use the `CdkDia.decorate` method in order to customize a diagram.
+
+## Local development
+
+To work on `cdk-dia` and this project locally, use `npm run link` script.

--- a/examples/decoration-example/README.md
+++ b/examples/decoration-example/README.md
@@ -2,6 +2,12 @@
 
 This example AWS-CDK project shows how one can use the `CdkDia.decorate` method in order to customize a diagram.
 
+Run `npm install` to install dependencies, then run the following to synthesize the CDK stack and automatically generate the diagram:
+
+```bash
+npm run synth
+```
+
 ## Local development
 
 To work on `cdk-dia` and this project locally, use `npm run link` script.

--- a/examples/decoration-example/lib/db-tier.ts
+++ b/examples/decoration-example/lib/db-tier.ts
@@ -2,8 +2,7 @@ import * as rds from "@aws-cdk/aws-rds"
 import * as cdk from "@aws-cdk/core"
 import * as ec2 from "@aws-cdk/aws-ec2"
 
-import {CdkDia, CdkDiaDecorator} from "cdk-dia/src/cdk"
-import {CollapseTypes} from "cdk-dia/src/diagram/component/customizable-attribute"
+import {CdkDia, CdkDiaDecorator, CollapseTypes} from "cdk-dia"
 
 export class Db extends rds.DatabaseCluster {
     constructor(scope: cdk.Construct, id: string, vpc: ec2.Vpc) {

--- a/examples/decoration-example/package.json
+++ b/examples/decoration-example/package.json
@@ -9,6 +9,8 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
+    "synth": "cdk synth",
+    "postsynth": "cdk-dia",
     "link": "(cd ../..; npm link) && npm link cdk-dia",
     "unlink": "npm unlink --no-save cdk-dia"
   },

--- a/examples/decoration-example/package.json
+++ b/examples/decoration-example/package.json
@@ -8,7 +8,9 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "link": "(cd ../..; npm link) && npm link cdk-dia",
+    "unlink": "npm unlink --no-save cdk-dia"
   },
   "devDependencies": {
     "@types/node": "10.17.27",

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
 export * from "./src/cdk/construct-decorator"
 export * from "./src/cdk"
-export * from "./src/graphviz"
+export * from "./src/render/graphviz"
 export * from "./src/diagram"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tsc && jest"
   },
   "bin": {
-    "cdk-dia": "bin/cli.js"
+    "cdk-dia": "dist/bin/cli.js"
   },
   "jest": {
     "testEnvironment": "node"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "🎡 Automated diagrams of CDK provisioned infrastructure",
   "scripts": {
-    "prepare": "./prepare-dist.sh",
+    "prepare": "tsc && cp -r icons dist && cp src/diagram/aws/awsResouceIconMatches.json dist/src/diagram/aws/awsResouceIconMatches.json",
     "test": "tsc && jest"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "🎡 Automated diagrams of CDK provisioned infrastructure",
   "scripts": {
     "build-watch": "tsc --watch",
-    "prepare": "tsc && cp -r icons dist && cp src/diagram/aws/awsResouceIconMatches.json dist/src/diagram/aws/awsResouceIconMatches.json",
+    "prepare": "tsc && cp src/diagram/aws/awsResouceIconMatches.json dist/src/diagram/aws/awsResouceIconMatches.json",
     "test": "tsc && jest"
   },
   "bin": {
@@ -16,7 +16,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "icons"
   ],
   "author": "Tom Roshko @pistazie",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "description": "🎡 Automated diagrams of CDK provisioned infrastructure",
   "scripts": {
+    "build-watch": "tsc --watch",
     "prepare": "tsc && cp -r icons dist && cp src/diagram/aws/awsResouceIconMatches.json dist/src/diagram/aws/awsResouceIconMatches.json",
     "test": "tsc && jest"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "🎡 Automated diagrams of CDK provisioned infrastructure",
   "scripts": {
-    "prepare-dist": "./prepare-dist.sh",
+    "prepare": "./prepare-dist.sh",
     "test": "tsc && jest"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "jest": {
     "testEnvironment": "node"
   },
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "**/*"
+    "dist"
   ],
   "author": "Tom Roshko @pistazie",
   "license": "MIT",

--- a/prepare-dist.sh
+++ b/prepare-dist.sh
@@ -1,5 +1,0 @@
-tsc --declarationDir ./dist --outDir ./dist
-cp package.json dist
-cp -r icons dist
-cp src/diagram/aws/awsResouceIconMatches.json dist/src/diagram/aws/awsResouceIconMatches.json
-cp README.md dist

--- a/smoke-test/smoke-test.sh
+++ b/smoke-test/smoke-test.sh
@@ -48,7 +48,6 @@ npm install -g typescript aws-cdk verdaccio
 verdaccio --config ./smoke-test/smoke-test-npm-local-repo-config.yml &
 
 # publish CDK-Dia to a locally running NPM registry for testing
-npm run prepare-dist
 cd dist
 npm version 9.9.${GITHUB_RUN_NUMBER} --commit-hooks false --git-tag-version false
 npm publish --registry http://localhost:4873

--- a/smoke-test/smoke-test.sh
+++ b/smoke-test/smoke-test.sh
@@ -6,7 +6,7 @@ prepareCdkProject(){
   TEST_CDK_PROJ_PATH=$1
   INSTALL_CDK_DIA_GLOBALLY=$2
 
-  echo "bootsrtapping a new AWS-CDK project at ${TEST_CDK_PROJ_PATH}"
+  echo "bootstrapping a new AWS-CDK project at ${TEST_CDK_PROJ_PATH}"
   mkdir -p $TEST_CDK_PROJ_PATH
   cd $TEST_CDK_PROJ_PATH
   cdk init sample-app --language typescript
@@ -52,5 +52,8 @@ npm version 9.9.${GITHUB_RUN_NUMBER} --commit-hooks false --git-tag-version fals
 npm publish --registry http://localhost:4873
 
 # Perform Tests Cases
-smokeTest false ./node_modules/.bin/cdk-dia # install in a project
-smokeTest true cdk-dia # install globally
+echo "smoketest with cdk-dia installed in a project's node_modules"
+smokeTest false ./node_modules/.bin/cdk-dia
+
+echo "smoketest with cdk-dia installed globally"
+smokeTest true cdk-dia

--- a/smoke-test/smoke-test.sh
+++ b/smoke-test/smoke-test.sh
@@ -48,7 +48,6 @@ npm install -g typescript aws-cdk verdaccio
 verdaccio --config ./smoke-test/smoke-test-npm-local-repo-config.yml &
 
 # publish CDK-Dia to a locally running NPM registry for testing
-cd dist
 npm version 9.9.${GITHUB_RUN_NUMBER} --commit-hooks false --git-tag-version false
 npm publish --registry http://localhost:4873
 

--- a/src/cdk-dia.ts
+++ b/src/cdk-dia.ts
@@ -15,7 +15,7 @@ export class CdkDia {
         const cdkTree = cdk.TreeJsonLoader.load(path.isAbsolute(treeJsonPath) ? treeJsonPath : path.join(process.cwd(), treeJsonPath))
 
         // Generate Diagram
-        const generator = new diagrams.AwsDiagramGenerator(new diagrams.AwsEdgeResolver(), new diagrams.AwsIconSupplier(`${cdkBasePath}`))
+        const generator = new diagrams.AwsDiagramGenerator(new diagrams.AwsEdgeResolver(), new diagrams.AwsIconSupplier(`${cdkBasePath}/dist`))
         const diagram = generator.generate(cdkTree, collapse, includedStacks)
 
         // Render diagram using Graphviz

--- a/src/cdk-dia.ts
+++ b/src/cdk-dia.ts
@@ -15,7 +15,7 @@ export class CdkDia {
         const cdkTree = cdk.TreeJsonLoader.load(path.isAbsolute(treeJsonPath) ? treeJsonPath : path.join(process.cwd(), treeJsonPath))
 
         // Generate Diagram
-        const generator = new diagrams.AwsDiagramGenerator(new diagrams.AwsEdgeResolver(), new diagrams.AwsIconSupplier(`${cdkBasePath}/dist`))
+        const generator = new diagrams.AwsDiagramGenerator(new diagrams.AwsEdgeResolver(), new diagrams.AwsIconSupplier(`${cdkBasePath}`))
         const diagram = generator.generate(cdkTree, collapse, includedStacks)
 
         // Render diagram using Graphviz

--- a/src/diagram/index.ts
+++ b/src/diagram/index.ts
@@ -1,5 +1,6 @@
 export * from "./diagram"
 export * from "./component/component"
+export * from "./component/customizable-attribute"
 export * from "./component/diagram-component"
 export * from "./component/root-component"
 export * from "./component/link"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "noUnusedParameters": true,
     "sourceMap": true,
     "esModuleInterop": true,
-    "declaration": true
+    "declaration": true,
+    "outDir": "./dist"
   },
   "include": [
     "src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
   },
   "include": [
     "src/**/*.ts",
-    "bin/**/*.ts"
+    "bin/**/*.ts",
+    "index.ts" 
   ],
   "exclude": [
     "node_modules/**/*"


### PR DESCRIPTION
Pre-requisite to https://github.com/pistazie/cdk-dia/pull/14 (that one continues on this work), so probably merge this one first.

This PR adjusts imports and package definitions to allow using `npm link` and use local cdk-dia workspace to be linked into dependant projects (for example the decoration-example I worked on). Also has some more refinements to make development cycle faster.

Let me know if you disagree with any of the changes. Open for feedback.