### PR TITLE
chore: add mapping for mac1 and mac2 ec2 instance families

### DIFF
--- a/src/diagram/aws/awsResouceIconMatches.json
+++ b/src/diagram/aws/awsResouceIconMatches.json
@@ -94,6 +94,8 @@
             "M5N": "icons/aws/Resource/Res_Compute/Res_48_Dark/Res_Amazon-EC2_M5n-Instance_48_Dark.png",
             "M6G": "icons/aws/Resource/Res_Compute/Res_48_Dark/Res_Amazon-EC2_M6g-Instance_48_Dark.png",
             "MAC": "icons/aws/Resource/Res_Compute/Res_48_Dark/Res_Amazon-EC2_Mac-Instance_48_Dark.png",
+            "MAC1": "icons/aws/Resource/Res_Compute/Res_48_Dark/Res_Amazon-EC2_Mac-Instance_48_Dark.png",
+            "MAC2": "icons/aws/Resource/Res_Compute/Res_48_Dark/Res_Amazon-EC2_Mac-Instance_48_Dark.png",
             "P2": "icons/aws/Resource/Res_Compute/Res_48_Dark/Res_Amazon-EC2_P2-Instance_48_Dark.png",
             "P3": "icons/aws/Resource/Res_Compute/Res_48_Dark/Res_Amazon-EC2_P3-Instance_48_Dark.png",
             "P3DN": "icons/aws/Resource/Res_Compute/Res_48_Dark/Res_Amazon-EC2_P3dn-Instance_48_Dark.png",


### PR DESCRIPTION
This is a simple PR to support the new Mac1 and Mac2 instance types, which currently throw an exception when cdk-dia is run on a repo using them:
```
Uncaught TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null
    at new NodeError (node:internal/errors:372:5)
    at validateString (node:internal/validators:120:11)
    at Object.join (node:path:1172:7)
    at AwsIconSupplier.instanceIconByFamily (file:///usr/local/lib/node_modules/cdk-dia/dist/src/diagram/aws/aws-icon-supplier.js:82:46)
    at AwsIconSupplier.matchEC2InstanceIcon (file:///usr/local/lib/node_modules/cdk-dia/dist/src/diagram/aws/aws-icon-supplier.js:64:21)
    at AwsIconSupplier.matchIcon (file:///usr/local/lib/node_modules/cdk-dia/dist/src/diagram/aws/aws-icon-supplier.js:35:29)
    at AwsDiagramGenerator.generateCfnComponent (file:///usr/local/lib/node_modules/cdk-dia/dist/src/diagram/aws/aws-diagram-generator.js:153:40)
    at AwsDiagramGenerator.generateComponent (file:///usr/local/lib/node_modules/cdk-dia/dist/src/diagram/aws/aws-diagram-generator.js:77:30)
    at AwsDiagramGenerator.generateSubTree (file:///usr/local/lib/node_modules/cdk-dia/dist/src/diagram/aws/aws-diagram-generator.js:63:32)
    at file:///usr/local/lib/node_modules/cdk-dia/dist/src/diagram/aws/aws-diagram-generator.js:67:41
```
This re-uses the base MAC instance icon, as no new icons are available for mac1 and mac2 instances at this time.