### PR TITLE
--collapse-double-clusters command line option

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -8,9 +8,10 @@ import * as rendering from "../src/render/index"
 async function initCli(): Promise<cdkDiaCliArgs> {
 
     return yargs(process.argv.slice(2)).options({
-        'cdk-tree-path': {type: 'string', alias: 'tree', default: 'cdk.out/tree.json', describe: 'Path of synthesized cdk cloud assembly'},
+        'cdk-tree-path': {type: 'string', alias: 'tree', default: 'cdk.out/tree.json', describe: 'Path of synthesized CDK cloud assembly'},
         'target-path': {type: 'string', alias: 'target', default: 'diagram.png', describe: 'Target path for rendered PNG'},
-        'collapse': {type: 'boolean', default: true, describe: 'Collapse CDK Constructs'},
+        'collapse': {type: 'boolean', default: true, describe: 'Collapse CDK constructs'},
+        'collapse-double-clusters': {type: 'boolean', default: true, describe: 'Collapse CDK constructs with one child that is a cluster itself'},
         'stacks': {type: 'array', describe: 'Stacks to include (if not specified all stacks are diagramed)'},
         'rendering': {type: 'string', choices:[ Renderers.GRAPHVIZ, Renderers.CYTOSCAPE],default: Renderers.GRAPHVIZ, describe: 'The rendering engine to use'}
     }).version(false).argv
@@ -31,6 +32,7 @@ async function generateDiagram(args: cdkDiaCliArgs) {
         args["cdk-tree-path"],
         args["target-path"],
         args.collapse,
+        args["collapse-double-clusters"],
         packageBasePath,
         includedStacks,
         args["rendering"])
@@ -71,6 +73,7 @@ interface cdkDiaCliArgs {
     'cdk-tree-path': string,
     'target-path': string,
     collapse: boolean,
+    'collapse-double-clusters': boolean,
     stacks: (string | number)[] | undefined,
     rendering: Renderers
 }

--- a/src/cdk-dia.ts
+++ b/src/cdk-dia.ts
@@ -14,6 +14,7 @@ export class CdkDia {
     async generateDiagram(treeJsonPath: string,
                           targetPath: string,
                           collapse: boolean,
+                          collapseDoubleClusters: boolean,
                           cdkBasePath: string = require.resolve('cdk-dia/package.json'),
                           includedStacks: string[] | false = false,
                           renderer: Renderers) {
@@ -23,7 +24,7 @@ export class CdkDia {
 
         // Generate Diagram
         const generator = new diagrams.AwsDiagramGenerator(new diagrams.AwsEdgeResolver(), new diagrams.AwsIconSupplier(`${cdkBasePath}`))
-        const diagram = generator.generate(cdkTree, collapse, includedStacks)
+        const diagram = generator.generate(cdkTree, collapse, collapseDoubleClusters, includedStacks)
 
         // Render diagram using Graphviz
         switch (renderer) {

--- a/src/diagram/aws/aws-diagram-generator.ts
+++ b/src/diagram/aws/aws-diagram-generator.ts
@@ -21,7 +21,7 @@ export class AwsDiagramGenerator extends DiagramGenerator{
         this.iconSupplier = iconSupplier
     }
 
-    generate(cdkTree: cdk.Tree, collapse: boolean, includedStacks: string[] | false = false): Diagram {
+    generate(cdkTree: cdk.Tree, collapse: boolean, collapseDoubleClusters: boolean, includedStacks: string[] | false = false): Diagram {
 
         const diagram = new Diagram()
         const cdkRoot = cdkTree.tree
@@ -42,7 +42,7 @@ export class AwsDiagramGenerator extends DiagramGenerator{
         this.removeCdkAssets(diagram.root)
 
         // collapse "DoubleClusters" - components which have only one child which is a Cluster it self - prevents multiple frames
-        diagram.root = this.collapseDoubleClusters(diagram.root)
+        if (collapseDoubleClusters) diagram.root = this.collapseDoubleClusters(diagram.root)
 
         // remove cross-stack edges as they make diagrams very "loaded" and "verbose". should allow user to override this as in small CDK apps it does male sense to connect
         this.removeCrossStackEdges(diagram.root)

--- a/src/diagram/tests/generator.test.ts
+++ b/src/diagram/tests/generator.test.ts
@@ -31,7 +31,8 @@ describe("setting specific Stacks works as expected", () => {
         id: `collapsed`,
         jsonTreeFile: "multiple-similar-stacks",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     }
 
     it(`it only diagrams the "microservice1" stack`, () => {
@@ -56,7 +57,8 @@ describe("setting specific Stacks works as expected", () => {
         id:`non-collapsed`,
             jsonTreeFile: "cdk_pipeline_with_stages_stacks_and_construct_infos",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     }
 
     it(`use can use a path of a stack which is nested`, () => {
@@ -179,5 +181,5 @@ export function givenDiagram(testConf: TestConf, includedStacks: string[] | fals
     const cdkTree = cdk.TreeJsonLoader.load(`${testConf.cdkTreePath}${testConf.jsonTreeFile}.json`)
 
     const generator = new diagrams.AwsDiagramGenerator(new AwsEdgeResolver(), new AwsIconSupplier(""))
-    return generator.generate(cdkTree, testConf.collapsed, includedStacks)
+    return generator.generate(cdkTree, testConf.collapsed, testConf.collapsedDoubleClusters, includedStacks)
 }

--- a/src/test-fixtures/testCases.ts
+++ b/src/test-fixtures/testCases.ts
@@ -4,121 +4,141 @@ export const testCases: TestConf[] = [
         id:`collapsed`,
         jsonTreeFile: "multiple-similar-stacks",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "multiple-similar-stacks",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "multiple-similar-stacks-with-usage-of-collapsing-customizer",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`non-collapsed`,
         jsonTreeFile: "multiple-similar-stacks-with-usage-of-collapsing-customizer",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
     {
         id:`non-collapsed`,
         jsonTreeFile: "function-and-queue",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "function-and-queue",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`non-collapsed`,
         jsonTreeFile: "the-eventbridge-etl",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "the-eventbridge-etl",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`non-collapsed`,
         jsonTreeFile: "2_queues-are-subscribed-to-a-topic",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "2_queues-are-subscribed-to-a-topic",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`non-collapsed`,
         jsonTreeFile: "fargate-service-with-vpc",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "fargate-service-with-vpc",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`non-collapsed`,
         jsonTreeFile: "cloudstructs-static-website",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "cloudstructs-static-website",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`non-collapsed`,
         jsonTreeFile: "ec-loadbalancer-rds",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "ec-loadbalancer-rds",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "cdk_pipeline_with_stages_stacks_and_construct_infos",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`non-collapsed`,
         jsonTreeFile: "custom-resource",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed`,
         jsonTreeFile: "custom-resource",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: true
+        collapsed: true,
+        collapsedDoubleClusters: true
     },
     {
         id:`collapsed-dontRemoveCrossStackEdges`,
         jsonTreeFile: "two-stack-with-a-relationship",
         cdkTreePath: "src/test-fixtures/",
-        collapsed: false
+        collapsed: false,
+        collapsedDoubleClusters: true
     },
 ]
 
@@ -127,4 +147,5 @@ export interface TestConf {
     jsonTreeFile: string
     cdkTreePath: string
     collapsed: boolean
+    collapsedDoubleClusters: boolean
 }


### PR DESCRIPTION
Expose a command line option for the following behavior:
https://github.com/pistazie/cdk-dia/blob/dcd3237ee89deeccc8f29208e150ca0c959d1b30/src/diagram/aws/aws-diagram-generator.ts#L45

Closes #29 